### PR TITLE
Change rand and indoc to dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,9 @@ documentation = "https://cfallin.github.io/boolean_expression/boolean_expression
 license = "MIT"
 
 [dependencies]
-rand = "0.3"
 smallvec = "0.1"
 itertools = "0.4"
+
+[dev-dependencies]
+rand = "0.3"
 indoc = "0.2"

--- a/src/bdd.rs
+++ b/src/bdd.rs
@@ -696,6 +696,7 @@ where
     }
 }
 
+#[cfg(test)]
 mod test {
     use super::*;
     use std::cell::RefCell;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@
 extern crate itertools;
 extern crate smallvec;
 
+#[cfg(test)]
 #[macro_use]
 extern crate indoc;
 


### PR DESCRIPTION
Since they're only used in tests, they don't need to be kept around at runtime.

Fixes #6 