### PR TITLE
Update crates to current versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,10 @@ documentation = "https://cfallin.github.io/boolean_expression/boolean_expression
 license = "MIT"
 
 [dependencies]
-smallvec = "0.1"
-itertools = "0.4"
+smallvec = "1.4"
+itertools = "0.9"
 
 [dev-dependencies]
-rand = "0.3"
-indoc = "0.2"
+rand = "0.7"
+rand_xorshift = "0.2"
+indoc = "0.3"


### PR DESCRIPTION
This avoids dependencies on two versions of rand, and lets us use
the modern rand APIs.