### PR TITLE
Remove `Ord` bound on `T`

### DIFF
--- a/src/bdd.rs
+++ b/src/bdd.rs
@@ -333,7 +333,7 @@ impl LabelBDD {
 #[derive(Clone, Debug)]
 pub struct BDD<T>
 where
-    T: Clone + Debug + Eq + Ord + Hash,
+    T: Clone + Debug + Eq + Hash,
 {
     bdd: LabelBDD,
     labels: HashMap<T, BDDLabel>,
@@ -342,7 +342,7 @@ where
 
 impl<T> BDD<T>
 where
-    T: Clone + Debug + Eq + Ord + Hash,
+    T: Clone + Debug + Eq + Hash,
 {
     /// Produce a new, empty, BDD.
     pub fn new() -> BDD<T> {
@@ -583,7 +583,7 @@ pub trait BDDOutput<T, E> {
 /// required when its `persist()` or `persist_all()` method is called.
 pub struct PersistedBDD<T>
 where
-    T: Clone + Debug + Eq + Ord + Hash,
+    T: Clone + Debug + Eq + Hash,
 {
     bdd: BDD<T>,
     next_output_func: BDDFunc,
@@ -592,7 +592,7 @@ where
 
 impl<T> PersistedBDD<T>
 where
-    T: Clone + Debug + Eq + Ord + Hash,
+    T: Clone + Debug + Eq + Hash,
 {
     /// Create a new `PersistedBDD`.
     pub fn new() -> PersistedBDD<T> {
@@ -649,14 +649,14 @@ where
 /// `inject_label` and `inject_node` as appropriate to inject labels and nodes.
 pub struct BDDLoader<'a, T>
 where
-    T: Clone + Debug + Eq + Ord + Hash + 'a,
+    T: Clone + Debug + Eq + Hash + 'a,
 {
     bdd: &'a mut BDD<T>,
 }
 
 impl<'a, T> BDDLoader<'a, T>
 where
-    T: Clone + Debug + Eq + Ord + Hash + 'a,
+    T: Clone + Debug + Eq + Hash + 'a,
 {
     /// Create a new `BDDLoader` wrapping the given `bdd`. The `BDDLoader`
     /// holds a mutable reference to `bdd` until destroyed. `bdd` must be empty

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -14,10 +14,10 @@ use simplify;
 /// An `Expr` is a simple Boolean logic expression. It may contain terminals
 /// (i.e., free variables), constants, and the following fundamental operations:
 /// AND, OR, NOT.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Expr<T>
 where
-    T: Clone + Debug + Eq + Ord + Hash,
+    T: Clone + Debug + Eq + Hash,
 {
     /// A terminal (free variable). This expression node represents a value that
     /// is not known until evaluation time.
@@ -37,7 +37,7 @@ where
 
 impl<T> Expr<T>
 where
-    T: Clone + Debug + Eq + Ord + Hash,
+    T: Clone + Debug + Eq + Hash,
 {
     /// Returns `true` if this `Expr` is a terminal.
     pub fn is_terminal(&self) -> bool {
@@ -175,7 +175,7 @@ where
     pub fn map<F, R>(&self, f: F) -> Expr<R>
     where
         F: Fn(&T) -> R,
-        R: Clone + Debug + Eq + Ord + Hash,
+        R: Clone + Debug + Eq + Hash,
     {
         self.map1(&f)
     }
@@ -183,7 +183,7 @@ where
     fn map1<F, R>(&self, f: &F) -> Expr<R>
     where
         F: Fn(&T) -> R,
-        R: Clone + Debug + Eq + Ord + Hash,
+        R: Clone + Debug + Eq + Hash,
     {
         match self {
             &Expr::Terminal(ref t) => Expr::Terminal(f(t)),

--- a/src/simplify.rs
+++ b/src/simplify.rs
@@ -18,7 +18,7 @@ struct SimplifyContext<T> {
 
 impl<T> SimplifyContext<T>
 where
-    T: Clone + Debug + Eq + Ord + Hash,
+    T: Clone + Debug + Eq + Hash,
 {
     pub fn new() -> SimplifyContext<T> {
         SimplifyContext {
@@ -107,7 +107,7 @@ where
 
 pub fn simplify_via_laws<T>(e: Expr<T>) -> Expr<T>
 where
-    T: Clone + Debug + Eq + Ord + Hash,
+    T: Clone + Debug + Eq + Hash,
 {
     let mut ctx = SimplifyContext::new();
     let mut e = e;
@@ -124,7 +124,7 @@ where
 // `BDD::from_expr` and `BDD::to_expr`, so we don't replicate those tests here.
 pub fn simplify_via_bdd<T>(e: Expr<T>) -> Expr<T>
 where
-    T: Clone + Debug + Eq + Ord + Hash,
+    T: Clone + Debug + Eq + Hash,
 {
     let mut bdd = BDD::new();
     let f = bdd.from_expr(&e);
@@ -139,7 +139,7 @@ mod test {
 
     fn run_test<T>(orig: Expr<T>, expected: Expr<T>)
     where
-        T: Clone + Debug + Eq + Ord + Hash,
+        T: Clone + Debug + Eq + Hash,
     {
         let output = simplify_via_laws(orig.clone());
         println!(


### PR DESCRIPTION
Hi, thanks for publishing this crate! I'm trying to use `Expr<T>` with a struct where ordering doesn't make sense, but `Expr` requires that `T` is `Ord`. I don't actually see the ordering in use anywhere, though, and tests still passed after I removed it. With this change, more types of values can be used. Please let me know if I missed something!
Thanks!