### PR TITLE
Add an XOR gate

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -8,7 +8,7 @@ use std::cmp::Ord;
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::hash::Hash;
-use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, Not};
+use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not};
 
 use simplify;
 
@@ -96,6 +96,12 @@ where
     /// expressions.
     pub fn or(e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
         Expr::Or(Box::new(e1), Box::new(e2))
+    }
+
+    pub fn xor(e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
+        let nand = !(e1.clone() & e2.clone());
+        let or = e1 | e2;
+        nand & or
     }
 
     /// Evaluates the expression with a particular set of terminal assignments.
@@ -244,5 +250,25 @@ where
 {
     fn bitor_assign(&mut self, rhs: Expr<T>) {
         *self = Self::or(self.clone(), rhs);
+    }
+}
+
+impl<T> BitXor<Expr<T>> for Expr<T>
+where
+    T: Clone + Debug + Eq + Hash,
+{
+    type Output = Self;
+
+    fn bitxor(self, rhs: Expr<T>) -> Self::Output {
+        Self::xor(self, rhs)
+    }
+}
+
+impl<T> BitXorAssign<Expr<T>> for Expr<T>
+where
+    T: Clone + Debug + Eq + Hash,
+{
+    fn bitxor_assign(&mut self, rhs: Expr<T>) {
+        *self = Self::xor(self.clone(), rhs);
     }
 }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -15,6 +15,26 @@ use simplify;
 /// An `Expr` is a simple Boolean logic expression. It may contain terminals
 /// (i.e., free variables), constants, and the following fundamental operations:
 /// AND, OR, NOT.
+///
+/// ```
+/// use std::collections::HashMap;
+/// use boolean_expression::Expr;
+///
+/// #[derive(Clone, Hash, Eq, PartialEq, Debug)]
+/// enum RiverCrossing { Chicken, Fox, Grain }
+///
+/// let chicken = Expr::Terminal(RiverCrossing::Chicken);
+/// let fox_and_grain = Expr::Terminal(RiverCrossing::Fox) & Expr::Terminal(RiverCrossing::Grain);
+///
+/// let allowed = (!chicken.clone() & fox_and_grain.clone()) | (chicken & !fox_and_grain);
+/// let items = [
+///    (RiverCrossing::Grain, true),
+///    (RiverCrossing::Fox, true),
+/// ].iter().cloned().collect();
+///
+/// // nobody gets eaten!
+/// assert!(allowed.evaluate(&items));
+/// ```
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Expr<T>
 where


### PR DESCRIPTION
This PR adds the xor operator, implementing it with a simple gate.

This could be extracted into Expr and maybe sped up by using xor directly instead of creating a gate, which doubles the number of evaluations, but since adding new cases could be a breaking change, I decided to leave it.

I also added an example to `Expr` showing the bitwise operators and the `evaluate` method.

This is the reference when writing the xor gate. Maybe I should add a comment.

![bilde](https://user-images.githubusercontent.com/8715352/105496792-3ead0480-5cbe-11eb-8dab-0977fbf5166b.png)
