### PR TITLE
Implement From<T> for Expr<T>

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -246,3 +246,12 @@ where
         *self = Self::or(self.clone(), rhs);
     }
 }
+
+impl<T> From<T> for Expr<T>
+where
+    T: Clone + Debug + Eq + Hash,
+{
+    fn from(t: T) -> Self {
+        Expr::Terminal(t)
+    }
+}


### PR DESCRIPTION
This very simply allows `data.into() -> Expr::Terminal(data)`